### PR TITLE
Sampler Interface + PCG Implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCE_FILES
     base/camera.cu
     base/image.cu
     integrator/integrator.cu
+    samplers/pcg_sampler.cu
 )
 
 # Static library configurations
@@ -16,6 +17,7 @@ set_target_properties(gamma_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 target_include_directories(gamma_lib PUBLIC ${CMAKE_CURRENT_LIST_DIR}/base)
 target_include_directories(gamma_lib PUBLIC ${CMAKE_CURRENT_LIST_DIR}/geometry)
 target_include_directories(gamma_lib PUBLIC ${CMAKE_CURRENT_LIST_DIR}/integrator)
+target_include_directories(gamma_lib PUBLIC ${CMAKE_CURRENT_LIST_DIR}/samplers)
 target_include_directories(gamma_lib PUBLIC ${GLM_INCLUDE_DIR}/glm)
 
 # Executable configurations

--- a/src/base/camera.cu
+++ b/src/base/camera.cu
@@ -13,17 +13,21 @@ gm::PerspectiveCamera::PerspectiveCamera(const Vector3f &position,
   setCameraToWorld(position, lookAt, up);
 }
 
-gm::Ray gm::PerspectiveCamera::generate_ray(uint32_t xCoord, uint32_t yCoord) {
+gm::Ray gm::PerspectiveCamera::generate_ray(uint32_t xCoord, uint32_t yCoord,
+                                            const Vector2f &sample) {
   Vector3f origin;
   // Transform origin point using the camera-to-world matrix
   origin = cameraToWorld.multiplyPoint(origin);
 
   // Create a projection point on the image plane using normalized device
-  // coordinates.
-  float x = (2.0f * (xCoord + 0.5f) / static_cast<float>(imageWidth) - 1.0f) *
-            aspectRatio * scale;
-  float y =
-      (1.0f - 2.0f * (yCoord + 0.5f) / static_cast<float>(imageHeight)) * scale;
+  // coordinates. Move the initial point from the center using two samples
+  float x =
+      (2.0f * (xCoord + sample.x + 0.5f) / static_cast<float>(imageWidth) -
+       1.0f) *
+      aspectRatio * scale;
+  float y = (1.0f - 2.0f * (yCoord + sample.y + 0.5f) /
+                        static_cast<float>(imageHeight)) *
+            scale;
 
   // Position vector at the image plane looking in the negative z direction
   Vector3f direction(x, y, -1.0f);

--- a/src/base/camera.h
+++ b/src/base/camera.h
@@ -7,6 +7,7 @@
 
 #include "matrix.h"
 #include "ray.h"
+#include "vector.h"
 
 namespace gm {
 
@@ -22,8 +23,9 @@ class PerspectiveCamera {
                     const Vector3f &up, size_t imageWidth, size_t imageHeight,
                     float fov);
 
-  // Compute a new camera ray for the given raster space coordinate
-  Ray generate_ray(uint32_t xPos, uint32_t yPos);
+  /// Compute a new camera ray for the given raster space coordinate. Also
+  /// requires a sample to generate sampled coordinates
+  Ray generate_ray(uint32_t xPos, uint32_t yPos, const Vector2f &sample);
 
  private:
   void setCameraToWorld(const Vector3f &position, const Vector3f &lookAt,

--- a/src/base/sampler.h
+++ b/src/base/sampler.h
@@ -18,7 +18,7 @@ class Sampler {
   /// Because we anticipate having to generate a large amount of samples
   /// per pixel we store the spp inside a 64-bit integer
   /// TODO This should be user-defined in the future.
-  Sampler(int64_t samplesPerPixel)
+  Sampler(uint32_t samplesPerPixel)
       : samplesPerPixel(samplesPerPixel), currentPixelSampleIndex(0){};
 
   /// We plan on using a single sampler per thread, so we need to be able
@@ -43,10 +43,10 @@ class Sampler {
     return ++currentPixelSampleIndex < samplesPerPixel;
   }
 
-  int64_t samplesPerPixel;
+  uint32_t samplesPerPixel;
 
  protected:
-  int64_t currentPixelSampleIndex;
+  uint32_t currentPixelSampleIndex;
 };
 
 }  // namespace gm

--- a/src/base/sampler.h
+++ b/src/base/sampler.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <memory>
+
+#include "vector.h"
+
+namespace gm {
+
+/// Interface class for creating different types of samplers.
+/// These samplers should output random samples based on a
+/// uniform distribution in the range of [0, 1)^n where n is
+/// the number of dimensions. The samplers should create unique
+/// sequences based on the pixel that is being sampled.
+
+class Sampler {
+ public:
+  /// The Sampler is initialized with the number of samples per pixels.
+  /// Because we anticipate having to generate a large amount of samples
+  /// per pixel we store the spp inside a 64-bit integer
+  /// TODO This should be user-defined in the future.
+  Sampler(int64_t samplesPerPixel)
+      : samplesPerPixel(samplesPerPixel), currentPixelSampleIndex(0){};
+
+  /// We plan on using a single sampler per thread, so we need to be able
+  /// to clone samplers for each worker, otherwise we can run into noise
+  /// artifacts due to the fact that the same sequences are being reused.
+  virtual std::unique_ptr<Sampler> clone(int seed) = 0;
+
+  /// Generate a 1-dimensional sample given the current sample. The index
+  /// should correspond to the sample-per-pixel
+  virtual float get1D() = 0;
+
+  /// Generate a 1-dimensional sample given the current sample. The index
+  /// should correspond to the sample-per-pixel
+  virtual Vector2f get2D() = 0;
+
+  /// Convenience method to test camera sampling logic. In the beginning we only
+  /// need a single 2D sample for the image plane coordinates, but this method
+  /// can be expanded later on for various purposes (i.e. lens sampling for DoF)
+  Vector2f getCameraSamples(const Vector2i &pixel) { return get2D(); }
+
+  /// This increments the pixel index and also indicates the to the integrator
+  /// that it should stop using random samples after a given iteration
+  virtual bool startNextSample() {
+    return ++currentPixelSampleIndex < samplesPerPixel;
+  }
+
+  int64_t samplesPerPixel;
+
+ protected:
+  int64_t currentPixelSampleIndex;
+};
+
+}  // namespace gm

--- a/src/base/sampler.h
+++ b/src/base/sampler.h
@@ -26,12 +26,10 @@ class Sampler {
   /// artifacts due to the fact that the same sequences are being reused.
   virtual std::unique_ptr<Sampler> clone(int seed) = 0;
 
-  /// Generate a 1-dimensional sample given the current sample. The index
-  /// should correspond to the sample-per-pixel
+  /// Generates a 1-dimensional sample.
   virtual float get1D() = 0;
 
-  /// Generate a 1-dimensional sample given the current sample. The index
-  /// should correspond to the sample-per-pixel
+  /// Generate a 2-dimensional sample
   virtual Vector2f get2D() = 0;
 
   /// Convenience method to test camera sampling logic. In the beginning we only

--- a/src/integrator/integrator.cu
+++ b/src/integrator/integrator.cu
@@ -13,26 +13,52 @@ void gm::Integrator::pathtrace() {
   uint8_t *imageBuffer = image->getBuffer();
   size_t imageWidth = image->getWidth();
   size_t imageHeight = image->getHeight();
+  uint32_t samplesPerPixel = 4; // Can be configured later
 
   // Add a triangle going centered around (0, 0, -1)
   Triangle triangle(Vector3f(-0.5f, -0.5f, 0.0f), Vector3f(0.5f, -0.5f, 0.0f),
                     Vector3f(0.0f, 0.5f, 0.0f));
+
   for (uint32_t yCoord = 0; yCoord < imageHeight; ++yCoord) {
     for (uint32_t xCoord = 0; xCoord < imageWidth; ++xCoord) {
-      Ray ray = camera->generate_ray(xCoord, yCoord);
 
-      Vector3f hitColor(0.0f);
-      std::unique_ptr<Intersection> intersection =
-          std::make_unique<Intersection>();
-      if (triangle.intersect(ray, intersection)) {
-        // If we intersect the triangle set the hit color to red
-        hitColor = Vector3f(1.0f, 0.0f, 0.0f);
+      // Create a sampler here for now. The rendering loop will need to be
+      // rewritten anyways
+      PCGSampler sampler(Vector2i(xCoord, yCoord), samplesPerPixel);
+      // Initialize the pixel color
+      Vector3f pixelColor(0.0f);
+      for (uint32_t sample = 0; sample < samplesPerPixel; ++sample) {
+        // Get a 2D sample for the camera rays
+        Vector2f cameraSample = sampler.get2D();
+
+        if (xCoord == imageWidth / 2 && yCoord == imageHeight / 2) {
+          std::cout << "Sample: " << cameraSample.x << ", " << cameraSample.y
+                    << std::endl;
+        }
+
+        // Sample the primary rays
+        Ray ray = camera->generate_ray(xCoord, yCoord, cameraSample);
+
+        // Calculate an intersection with the scene
+        std::unique_ptr<Intersection> intersection =
+            std::make_unique<Intersection>();
+        if (triangle.intersect(ray, intersection)) {
+          // If we intersect the triangle set the hit color to red
+          pixelColor += Vector3f(1.0f, 0.0f, 0.0f);
+        }
+
+        // Advance the sampler state for the next sample
+        sampler.startNextSample();
       }
 
+      /// Apply basic anti-aliasing by averaging the samples per-pixel
+      pixelColor /= samplesPerPixel;
+
+      /// Store the output color
       size_t pixelIdx = (yCoord * imageWidth + xCoord) * image->getChannels();
-      imageBuffer[pixelIdx] = static_cast<uint8_t>(hitColor.x * 255.99);
-      imageBuffer[pixelIdx + 1] = static_cast<uint8_t>(hitColor.y * 255.99);
-      imageBuffer[pixelIdx + 2] = static_cast<uint8_t>(hitColor.z * 255.99);
+      imageBuffer[pixelIdx] = static_cast<uint8_t>(pixelColor.x * 255.99);
+      imageBuffer[pixelIdx + 1] = static_cast<uint8_t>(pixelColor.y * 255.99);
+      imageBuffer[pixelIdx + 2] = static_cast<uint8_t>(pixelColor.z * 255.99);
     }
   }
   image->writePNG("test.png");

--- a/src/integrator/integrator.h
+++ b/src/integrator/integrator.h
@@ -8,6 +8,7 @@
 #include "camera.h"
 #include "image.h"
 #include "intersection.h"
+#include "pcg_sampler.h"
 #include "sphere.h"
 #include "triangle.h"
 

--- a/src/samplers/pcg_sampler.cu
+++ b/src/samplers/pcg_sampler.cu
@@ -1,0 +1,46 @@
+#include "pcg_sampler.h"
+
+gm::PCGSampler::PCGSampler(const Vector2i &pixel, int64_t samplesPerPixel)
+    : Sampler(samplesPerPixel) {
+  rng_states = std::vector<pcg32_state>(samplesPerPixel);
+  uint64_t seed = pixel.x + pixel.y;
+
+  // Initialize each sample-per-pixel state
+  for (uint32_t idx = 0; idx < samplesPerPixel; ++idx) {
+    rng_states[idx].state = 0U;
+    rng_states[idx].inc = (((uint64_t)idx + 1) << 1u) | 1u;
+    next_pcg32(&rng_states[idx]);
+    rng_states[idx].state += (0x853c49e6748fea9bULL + seed);
+    next_pcg32(&rng_states[idx]);
+  }
+}
+
+std::unique_ptr<gm::Sampler> gm::PCGSampler::clone(int seed) {
+  // TODO Implement
+  return nullptr;
+}
+
+// Generate a single precision floating point value on the interval [0, 1)
+// Trick from MTGP: generate an uniformly distributed single precision number
+// in [1,2) and subtract 1.
+float gm::PCGSampler::get1D() {
+  union {
+    uint32_t u;
+    float f;
+  } x;
+  x.u = (next_pcg32(&rng_states[currentPixelSampleIndex]) >> 9) | 0x3f800000u;
+  return x.f - 1.0f;
+}
+
+gm::Vector2f gm::PCGSampler::get2D() { return Vector2f(get1D(), get1D()); }
+
+// http://www.pcg-random.org/download.html
+uint32_t gm::PCGSampler::next_pcg32(pcg32_state *rng) {
+  uint64_t oldstate = rng->state;
+  // Advance internal state
+  rng->state = oldstate * 6364136223846793005ULL + (rng->inc | 1);
+  // Calculate output function (XSH RR), uses old state for max ILP
+  uint32_t xorshifted = uint32_t(((oldstate >> 18u) ^ oldstate) >> 27u);
+  uint32_t rot = uint32_t(oldstate >> 59u);
+  return uint32_t((xorshifted >> rot) | (xorshifted << ((-rot) & 31)));
+}

--- a/src/samplers/pcg_sampler.cu
+++ b/src/samplers/pcg_sampler.cu
@@ -1,6 +1,6 @@
 #include "pcg_sampler.h"
 
-gm::PCGSampler::PCGSampler(const Vector2i &pixel, int64_t samplesPerPixel)
+gm::PCGSampler::PCGSampler(const Vector2i &pixel, uint32_t samplesPerPixel)
     : Sampler(samplesPerPixel) {
   rng_states = std::vector<pcg32_state>(samplesPerPixel);
   uint64_t seed = pixel.x + pixel.y;

--- a/src/samplers/pcg_sampler.h
+++ b/src/samplers/pcg_sampler.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "sampler.h"
+#include "vector.h"
+
+namespace gm {
+
+struct pcg32_state {
+  uint64_t state;  // RNG state for the sampler
+  uint64_t inc;    // Controls the selected RNG sequence (stream). Must be odd !
+};
+
+/// This class implements a sampler based on Permutable Congruential Generators.
+/// For for more information visit: https://www.pcg-random.org/
+/// This sampler should only be used initially for testing other features and
+/// will eventually be replaced by better low-discrepancy sequence generators.
+/// The generator is seeded using the pixel coordinate being sampled.
+class PCGSampler : public Sampler {
+ public:
+  PCGSampler(const Vector2i &pixel, int64_t samplesPerPixel);
+
+  std::unique_ptr<Sampler> clone(int seed) override;
+
+  float get1D() override;
+
+  Vector2f get2D() override;
+
+ private:
+  uint32_t next_pcg32(pcg32_state *rng);
+
+  std::vector<pcg32_state> rng_states;  // One state per sample
+};
+}  // namespace gm

--- a/src/samplers/pcg_sampler.h
+++ b/src/samplers/pcg_sampler.h
@@ -21,7 +21,7 @@ struct pcg32_state {
 /// The generator is seeded using the pixel coordinate being sampled.
 class PCGSampler : public Sampler {
  public:
-  PCGSampler(const Vector2i &pixel, int64_t samplesPerPixel);
+  PCGSampler(const Vector2i &pixel, uint32_t samplesPerPixel);
 
   std::unique_ptr<Sampler> clone(int seed) override;
 

--- a/src/samplers/pcg_sampler.h
+++ b/src/samplers/pcg_sampler.h
@@ -11,7 +11,7 @@ namespace gm {
 
 struct pcg32_state {
   uint64_t state;  // RNG state for the sampler
-  uint64_t inc;    // Controls the selected RNG sequence (stream). Must be odd !
+  uint64_t inc;    // Controls the selected RNG sequence (stream). Must be odd!
 };
 
 /// This class implements a sampler based on Permutable Congruential Generators.


### PR DESCRIPTION
The following changes were made:

1. Added a Sampler interface to give us basic functionality for generating samples
2. Added a PCGSampler class which is based on the [Permuted Congruential Sampler](https://www.pcg-random.org/)
3. Updated primary ray generation to use a 2D sample
4. Rewrote the rendering loop to include the option for multiple samples per pixel, as well as basic anti-aliasing

As a proof of concept the rendering loop prints the generated samples for each spp for the pixel at the image center, to verify that the samples are distributed between [0, 1). Shown below are also two images, one showing a single triangle that was rendered using sampled primary rays with 4 samples per pixel, as well as a close-up that shows that the pixel colors are being averaged properly.

Rendered triangle
![triangle](https://user-images.githubusercontent.com/894276/79047303-144df700-7c16-11ea-8c4d-fdef6af2c3e5.png)

Close-up of the above image
![triangle-aa](https://user-images.githubusercontent.com/894276/79047308-1a43d800-7c16-11ea-9ba7-08432a050a9b.png)


